### PR TITLE
Omitting 'as' results in syntax error with belongs to relationship

### DIFF
--- a/lib/surus/json/query.rb
+++ b/lib/surus/json/query.rb
@@ -50,7 +50,7 @@ module Surus
             association_scope = HasAndBelongsToManyScopeBuilder.new(original_scope, association).scope
             ArrayAggQuery.new(association_scope, association_options).to_sql
           end
-          "(#{subquery}) #{association_name}"
+          "(#{subquery}) as #{association_name}"
         end
       end
 


### PR DESCRIPTION
`Widget.all_json(include: :user)` with `Widget` belongs to `User`, `User` has many `Widget`s would not work without this fix.
