### PR TITLE
Handle has_one association

### DIFF
--- a/lib/surus/json/query.rb
+++ b/lib/surus/json/query.rb
@@ -48,6 +48,8 @@ module Surus
           association_type = if defined? ActiveRecord::Reflection::BelongsToReflection
             # Rails 4.2+
             case association
+            when ActiveRecord::Reflection::HasOneReflection
+              :has_one
             when ActiveRecord::Reflection::BelongsToReflection
               :belongs_to
             when ActiveRecord::Reflection::HasManyReflection
@@ -63,6 +65,9 @@ module Surus
           subquery = case association_type
           when :belongs_to
             association_scope = BelongsToScopeBuilder.new(original_scope, association).scope
+            RowQuery.new(association_scope, association_options).to_sql
+          when :has_one
+            association_scope = HasManyScopeBuilder.new(original_scope, association).scope
             RowQuery.new(association_scope, association_options).to_sql
           when :has_many
             association_scope = HasManyScopeBuilder.new(original_scope, association).scope

--- a/spec/database.yml
+++ b/spec/database.yml
@@ -2,3 +2,4 @@ test:
   adapter: postgresql
   encoding: unicode
   database: surus_test
+

--- a/spec/database_structure.sql
+++ b/spec/database_structure.sql
@@ -62,6 +62,27 @@ CREATE TABLE users(
 
 
 
+DROP TABLE IF EXISTS bios CASCADE;
+
+CREATE TABLE bios(
+  id serial PRIMARY KEY,
+  body text NOT NULL,
+  website_url varchar NOT NULL,
+  author_id integer NOT NULL REFERENCES users
+);
+
+
+
+DROP TABLE IF EXISTS avatars CASCADE;
+
+CREATE TABLE avatars(
+  id serial PRIMARY KEY,
+  url varchar NOT NULL,
+  author_id integer NOT NULL REFERENCES users
+);
+
+
+
 DROP TABLE IF EXISTS forums CASCADE;
 
 CREATE TABLE forums(

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -17,5 +17,20 @@ FactoryGirl.define do
   factory :user, aliases: [:author] do
     name { Faker::Internet.user_name }
     email { Faker::Internet.email }
+    after(:build) do |user|
+      user.bio ||= FactoryGirl.build(:bio, author: user)
+      user.avatar ||= FactoryGirl.build(:avatar, author: user)
+    end
+  end
+
+  factory :bio do
+    author
+    body { Faker::Lorem.paragraph }
+    website_url { Faker::Internet.url }
+  end
+
+  factory :avatar do
+    author
+    url { Faker::Avatar.image }
   end
 end

--- a/spec/json/json_spec.rb
+++ b/spec/json/json_spec.rb
@@ -69,6 +69,33 @@ describe 'json' do
         expect(find_json).to eq(to_json)
       end
 
+      it 'includes entire has_one object' do
+        user = FactoryGirl.create :user
+        to_json = Oj.load user.to_json(include: :bio)
+        find_json = Oj.load User.find_json(user.id, include: :bio)
+        expect(find_json).to eq(to_json)
+      end
+
+      it 'filters by has_one conditions' do
+        user = FactoryGirl.create :user
+        find_json = Oj.load User.find_json(user.id, include: :bio_with_impossible_conditions)
+        expect(find_json.fetch('bio_with_impossible_conditions')).to be_nil
+      end
+
+      it 'includes multiple entire has_one objects' do
+        user = FactoryGirl.create :user
+        to_json = Oj.load user.to_json(include: [:bio, :avatar])
+        find_json = Oj.load User.find_json(user.id, include: [:bio, :avatar])
+        expect(find_json).to eq(to_json)
+      end
+
+      it 'includes only selected columns of has_one object' do
+        user = FactoryGirl.create :user
+        to_json = Oj.load user.to_json(include: {bio: {only: [:id, :body]}})
+        find_json = Oj.load User.find_json(user.id, include: {bio: {columns: [:id, :body]}})
+        expect(find_json).to eq(to_json)
+      end
+
       it 'includes entire has_many association' do
         user = FactoryGirl.create :user
         posts = FactoryGirl.create_list :post, 2, author: user

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,21 @@ class User < ActiveRecord::Base
 
   # association name is reserved word in PostgreSQL
   has_many :rows, foreign_key: :author_id, class_name: 'Post', table_name: 'posts'
+
+  has_one :bio, foreign_key: :author_id
+  has_one :avatar, foreign_key: :author_id
+  has_one :bio_with_impossible_conditions,
+    -> { where '1=2' },
+    foreign_key: :author_id,
+    class_name: 'Bio'
+end
+
+class Bio < ActiveRecord::Base
+  belongs_to :author, class_name: 'User'
+end
+
+class Avatar < ActiveRecord::Base
+  belongs_to :author, class_name: 'User'
 end
 
 class Forum < ActiveRecord::Base

--- a/surus.gemspec
+++ b/surus.gemspec
@@ -34,6 +34,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pg'
   s.add_development_dependency 'pry', '~> 0.9.11'
   s.add_development_dependency 'factory_girl', '~> 4.2.0'
-  s.add_development_dependency 'faker', '~> 1.1.2'
+  s.add_development_dependency 'faker', '~> 1.4.3'
   s.add_development_dependency 'rake'
 end


### PR DESCRIPTION
Hi,

First of all, great gem, its really awesome. Some of my queries that was taking 3800ms are now taking only 70ms to render with the all_json method!

I just had one problem with it. The has_one association was not handled so it generated queries with empty subqueries, which crashed:

```
select row_to_json(t) from (SELECT "users"."id", "users"."name", "users"."email", () "bio" FROM "users" WHERE "users"."id" = 39) t
```

I fixed it by simply using the HasManyScopeBuilder but returning a RowQuery instead of an ArrayAggQuery. I also added some specs.

If something is wrong, just tell me and I will fix it.
Have a good day!