### PR TITLE
Correction prepared statements

### DIFF
--- a/lib/surus/json/query.rb
+++ b/lib/surus/json/query.rb
@@ -15,11 +15,12 @@ module Surus
       end
 
       def subquery_sql
-        if options.key?(:columns) || options.key?(:include)
-          select(columns.map(&:to_s).join(', ')).to_sql_with_binding_params
+        scope = if options.key?(:columns) || options.key?(:include)
+          select(columns.map(&:to_s).join(', '))
         else
-          original_scope.to_sql_with_binding_params
+          original_scope
         end
+	(scope.respond_to?(:to_sql_with_binding_params) ? scope.to_sql_with_binding_params : scope.to_sql)
       end
 
       def columns

--- a/lib/surus/json/query.rb
+++ b/lib/surus/json/query.rb
@@ -16,9 +16,9 @@ module Surus
 
       def subquery_sql
         if options.key?(:columns) || options.key?(:include)
-          select(columns.map(&:to_s).join(', ')).to_sql
+          select(columns.map(&:to_s).join(', ')).to_sql_with_binding_params
         else
-          original_scope.to_sql
+          original_scope.to_sql_with_binding_params
         end
       end
 

--- a/lib/surus/version.rb
+++ b/lib/surus/version.rb
@@ -1,3 +1,3 @@
 module Surus
-  VERSION = "0.6.0"
+  VERSION = "0.6.1"
 end


### PR DESCRIPTION
When working with nested models, activerecord can use prepared statements like the following : 

 ```
$> Cursus.find(1).projects.to_sql
=> "SELECT \"projects\".* FROM \"projects\" INNER JOIN \"cursus_projects\" ON \"projects\".\"id\" = \"cursus_projects\".\"project_id\" WHERE \"cursus_projects\".\"cursus_id\" = $1" #(note the $1)
```

When coupling with all_json, it creates an `PG::ProtocolViolation: ERROR: bind message supplies 0 parameters, but prepared statement "" requires 1` error.

Replace `to_sql` by `to_sql_with_binding_params` fixes the problem.