### PR TITLE
Prefix column name with table names in query conditions

### DIFF
--- a/lib/surus/array/scope.rb
+++ b/lib/surus/array/scope.rb
@@ -8,7 +8,7 @@ module Surus
       #   User.array_has(:permissions, "manage_users", "manage_roles")
       #   User.array_has(:permissions, ["manage_users", "manage_roles"])
       def array_has(column, *values)
-        where("#{connection.quote_column_name(column)} @> ARRAY[?]#{array_cast(column)}", values.flatten)
+        where("#{connection.quote_table_name(table_name)}.#{connection.quote_column_name(column)} @> ARRAY[?]#{array_cast(column)}", values.flatten)
       end
 
       # Adds where condition that requires column to contain any values
@@ -18,7 +18,7 @@ module Surus
       #   User.array_has_any(:permissions, "manage_users", "manage_roles")
       #   User.array_has_any(:permissions, ["manage_users", "manage_roles"])
       def array_has_any(column, *values)
-        where("#{connection.quote_column_name(column)} && ARRAY[?]#{array_cast(column)}", values.flatten)
+        where("#{connection.quote_table_name(table_name)}.#{connection.quote_column_name(column)} && ARRAY[?]#{array_cast(column)}", values.flatten)
       end
 
       private

--- a/lib/surus/hstore/scope.rb
+++ b/lib/surus/hstore/scope.rb
@@ -6,33 +6,33 @@ module Surus
       # Example:
       #   User.hstore_has_pairs(:properties, "favorite_color" => "green")
       def hstore_has_pairs(column, hash)
-        where("#{connection.quote_column_name(column)} @> ?", Serializer.new.dump(hash))
+        where("#{connection.quote_table_name(table_name)}.#{connection.quote_column_name(column)} @> ?", Serializer.new.dump(hash))
       end
-      
+
       # Adds a where condition that requires column to contain key
       #
       # Example:
       #   User.hstore_has_key(:properties, "favorite_color")
       def hstore_has_key(column, key)
-        where("#{connection.quote_column_name(column)} ? :key", :key => key)    
+        where("#{connection.quote_table_name(table_name)}.#{connection.quote_column_name(column)} ? :key", :key => key)
       end
-      
+
       # Adds a where condition that requires column to contain all keys.
       #
       # Example:
       #    User.hstore_has_all_keys(:properties, "favorite_color", "favorite_song")
       #    User.hstore_has_all_keys(:properties, ["favorite_color", "favorite_song"])
       def hstore_has_all_keys(column, *keys)
-        where("#{connection.quote_column_name(column)} ?& ARRAY[:keys]", :keys => keys.flatten)
+        where("#{connection.quote_table_name(table_name)}.#{connection.quote_column_name(column)} ?& ARRAY[:keys]", :keys => keys.flatten)
       end
-      
+
       # Adds a where condition that requires column to contain any keys.
       #
       # Example:
       #    User.hstore_has_any_keys(:properties, "favorite_color", "favorite_song")
       #    User.hstore_has_any_keys(:properties, ["favorite_color", "favorite_song"])
       def hstore_has_any_keys(column, *keys)
-        where("#{connection.quote_column_name(column)} ?| ARRAY[:keys]", :keys => keys.flatten)
+        where("#{connection.quote_table_name(table_name)}.#{connection.quote_column_name(column)} ?| ARRAY[:keys]", :keys => keys.flatten)
       end
     end
   end


### PR DESCRIPTION
Hi,

First of all – thanks for creating this gem, it’s really useful in my project.

I recently encountered one issue though.
I’ve got `Blog` and `BlogPost` models with one–to–many relation. Both models contains column "flag" (array). When I’m searching for `BlogPost.array_has(:flag, ["spam"])`, everything works just fine.
Problem is with column ambiguity when I’m joining Blog:

```
BlogPost.joins(:blog).where(scanned: true).array_has(:flags, ["spam"]).limit(5)
PG::AmbiguousColumn: ERROR:  column reference "flags" is ambiguous
LINE 1: ...."blog_id" WHERE "blog_posts"."scanned" = $1 AND ("flags" @>...
                                                             ^
```` 

In my PR, instead of using `"flags" @> ARRAY['spam']::character` it uses `"blog_posts"."flags"` which solves that issue.

The only thing which I’m not really sure about is how to add ability to search by `blog.flags` – it would probably require some API change (eg. (`array_has(blog: { flags: ["spam"] }, blog_posts: { flag: ["casino"] })` ) – what do you think about that?