### PR TITLE
Upgrade to Ruby 1.9 Hash Syntax

### DIFF
--- a/bench/benchmark_helper.rb
+++ b/bench/benchmark_helper.rb
@@ -31,7 +31,7 @@ class EavMasterRecord < ActiveRecord::Base
   def persist_properties
     eav_detail_records.clear
     @properties.each do |k,v|
-      eav_detail_records.create! :key => k, :value => v
+      eav_detail_records.create! key: k, value: v
     end
   end
 end

--- a/bench/hstore_find.rb
+++ b/bench/hstore_find.rb
@@ -45,7 +45,7 @@ if eav
   print "Creating EAV test data... "
   EavMasterRecord.transaction do
     num_records.times do |i|
-      EavMasterRecord.create! :properties => key_value_pairs[i]
+      EavMasterRecord.create! properties: key_value_pairs[i]
     end
   end
   puts "Done."
@@ -54,7 +54,7 @@ end
 print "Creating Surus test data... "
 SurusKeyValueRecord.transaction do
   num_records.times do |i|
-    SurusKeyValueRecord.create! :properties => key_value_pairs[i]
+    SurusKeyValueRecord.create! properties: key_value_pairs[i]
   end
 end
 puts "Done."
@@ -63,7 +63,7 @@ if yaml
   print "Creating YAML test data... "
   YamlKeyValueRecord.transaction do
     num_records.times do |i|
-      YamlKeyValueRecord.create! :properties => key_value_pairs[i]
+      YamlKeyValueRecord.create! properties: key_value_pairs[i]
     end
   end
   puts "Done."

--- a/bench/synchronous_commit.rb
+++ b/bench/synchronous_commit.rb
@@ -20,22 +20,22 @@ puts "Done."
 random_io = StringIO.new(random_string)
 
 create_wide_record = lambda do
-  WideRecord.create! :a => random_io.read(wide_field_width),
-    :b => random_io.read(wide_field_width),
-    :c => random_io.read(wide_field_width),
-    :d => random_io.read(wide_field_width),
-    :e => random_io.read(wide_field_width),
-    :f => random_io.read(wide_field_width),
-    :g => random_io.read(wide_field_width),
-    :h => random_io.read(wide_field_width),
-    :i => random_io.read(wide_field_width),
-    :j => random_io.read(wide_field_width)
+  WideRecord.create! a: random_io.read(wide_field_width),
+    b: random_io.read(wide_field_width),
+    c: random_io.read(wide_field_width),
+    d: random_io.read(wide_field_width),
+    e: random_io.read(wide_field_width),
+    f: random_io.read(wide_field_width),
+    g: random_io.read(wide_field_width),
+    h: random_io.read(wide_field_width),
+    i: random_io.read(wide_field_width),
+    j: random_io.read(wide_field_width)
 end
 
 create_narrow_record = lambda do
-  NarrowRecord.create! :a => random_io.read(narrow_field_width),
-    :b => random_io.read(narrow_field_width),
-    :c => random_io.read(narrow_field_width)
+  NarrowRecord.create! a: random_io.read(narrow_field_width),
+    b: random_io.read(narrow_field_width),
+    c: random_io.read(narrow_field_width)
 end
 
 { "narrow" => create_narrow_record, "wide" => create_wide_record }.each do |text, create_record|

--- a/lib/surus/hstore/scope.rb
+++ b/lib/surus/hstore/scope.rb
@@ -14,7 +14,7 @@ module Surus
       # Example:
       #   User.hstore_has_key(:properties, "favorite_color")
       def hstore_has_key(column, key)
-        where("#{connection.quote_table_name(table_name)}.#{connection.quote_column_name(column)} ? :key", :key => key)
+        where("#{connection.quote_table_name(table_name)}.#{connection.quote_column_name(column)} ? :key", key: key)
       end
 
       # Adds a where condition that requires column to contain all keys.
@@ -23,7 +23,7 @@ module Surus
       #    User.hstore_has_all_keys(:properties, "favorite_color", "favorite_song")
       #    User.hstore_has_all_keys(:properties, ["favorite_color", "favorite_song"])
       def hstore_has_all_keys(column, *keys)
-        where("#{connection.quote_table_name(table_name)}.#{connection.quote_column_name(column)} ?& ARRAY[:keys]", :keys => keys.flatten)
+        where("#{connection.quote_table_name(table_name)}.#{connection.quote_column_name(column)} ?& ARRAY[:keys]", keys: keys.flatten)
       end
 
       # Adds a where condition that requires column to contain any keys.
@@ -32,7 +32,7 @@ module Surus
       #    User.hstore_has_any_keys(:properties, "favorite_color", "favorite_song")
       #    User.hstore_has_any_keys(:properties, ["favorite_color", "favorite_song"])
       def hstore_has_any_keys(column, *keys)
-        where("#{connection.quote_table_name(table_name)}.#{connection.quote_column_name(column)} ?| ARRAY[:keys]", :keys => keys.flatten)
+        where("#{connection.quote_table_name(table_name)}.#{connection.quote_column_name(column)} ?| ARRAY[:keys]", keys: keys.flatten)
       end
     end
   end

--- a/lib/surus/synchronous_commit/model.rb
+++ b/lib/surus/synchronous_commit/model.rb
@@ -3,7 +3,7 @@ module Surus
     # synchronous_commit and synchronous_commit= are delegated to the underlying
     # connection object
     module Model
-      delegate :synchronous_commit, :synchronous_commit=, :to => :connection
+      delegate :synchronous_commit, :synchronous_commit=, to: :connection
     end
   end
 end

--- a/spec/array/scope_spec.rb
+++ b/spec/array/scope_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
 describe Surus::Array::Scope do
-  let!(:empty) { TextArrayRecord.create! :texts => [] }
+  let!(:empty) { TextArrayRecord.create! texts: [] }
 
   context "array_has" do
-    let!(:match) { TextArrayRecord.create! :texts => %w{a b} }
-    let!(:missing_element) { TextArrayRecord.create! :texts => %w{a} }
+    let!(:match) { TextArrayRecord.create! texts: %w{a b} }
+    let!(:missing_element) { TextArrayRecord.create! texts: %w{a} }
 
     def self.shared_examples
       it { should include(match) }
@@ -30,8 +30,8 @@ describe Surus::Array::Scope do
   end
 
   context "array_has_any" do
-    let!(:match) { TextArrayRecord.create! :texts => %w{a b} }
-    let!(:missing_element) { TextArrayRecord.create! :texts => %w{a} }
+    let!(:match) { TextArrayRecord.create! texts: %w{a b} }
+    let!(:missing_element) { TextArrayRecord.create! texts: %w{a} }
 
     def self.shared_examples
       it { should include(match) }
@@ -56,7 +56,7 @@ describe Surus::Array::Scope do
   end
 
   it "casts between varchar[] and text[]" do
-    record = VarcharArrayRecord.create! :varchars => %w{a b}
+    record = VarcharArrayRecord.create! varchars: %w{a b}
     expect(VarcharArrayRecord.array_has_any(:varchars, "a")).to include(record)
     expect(VarcharArrayRecord.array_has_any(:varchars, "c")).to_not include(record)
     expect(VarcharArrayRecord.array_has_any(:varchars, "b", "c")).to include(record)

--- a/spec/hstore/scope_spec.rb
+++ b/spec/hstore/scope_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
 describe Surus::Hstore::Scope do
-  let!(:empty) { HstoreRecord.create! :properties => {} }
+  let!(:empty) { HstoreRecord.create! properties: {} }
 
   context "hstore_has_pairs" do
-    let!(:match) { HstoreRecord.create! :properties => { "a" => "1", "b" => "2", "c" => "3" } }
-    let!(:missing_key) { HstoreRecord.create! :properties => { "a" => "1", "c" => "3" } }
-    let!(:wrong_value) { HstoreRecord.create! :properties => { "a" => "1", "b" => "5" } }
+    let!(:match) { HstoreRecord.create! properties: { "a" => "1", "b" => "2", "c" => "3" } }
+    let!(:missing_key) { HstoreRecord.create! properties: { "a" => "1", "c" => "3" } }
+    let!(:wrong_value) { HstoreRecord.create! properties: { "a" => "1", "b" => "5" } }
 
     subject { HstoreRecord.hstore_has_pairs(:properties, "a" => "1", "b" => "2") }
 
@@ -17,8 +17,8 @@ describe Surus::Hstore::Scope do
   end
 
   context "hstore_has_key" do
-    let!(:match) { HstoreRecord.create! :properties => { "a" => "1", "b" => "2" } }
-    let!(:missing_key) { HstoreRecord.create! :properties => { "a" => "1", "c" => "3" } }
+    let!(:match) { HstoreRecord.create! properties: { "a" => "1", "b" => "2" } }
+    let!(:missing_key) { HstoreRecord.create! properties: { "a" => "1", "c" => "3" } }
 
     subject { HstoreRecord.hstore_has_key(:properties, "b") }
 
@@ -28,9 +28,9 @@ describe Surus::Hstore::Scope do
   end
 
   context "hstore_has_all_keys" do
-    let!(:match) { HstoreRecord.create! :properties => { "a" => "1", "b" => "2", "c" => "3" } }
-    let!(:missing_one_key) { HstoreRecord.create! :properties => { "b" => "2", "c" => "3" } }
-    let!(:missing_all_keys) { HstoreRecord.create! :properties => { "f" => "1", "g" => "2" } }
+    let!(:match) { HstoreRecord.create! properties: { "a" => "1", "b" => "2", "c" => "3" } }
+    let!(:missing_one_key) { HstoreRecord.create! properties: { "b" => "2", "c" => "3" } }
+    let!(:missing_all_keys) { HstoreRecord.create! properties: { "f" => "1", "g" => "2" } }
 
     def self.shared_examples
       it { should include(match) }
@@ -51,9 +51,9 @@ describe Surus::Hstore::Scope do
   end
 
   context "hstore_has_any_key" do
-    let!(:match_1) { HstoreRecord.create! :properties => { "a" => "1", "c" => "3" } }
-    let!(:match_2) { HstoreRecord.create! :properties => { "b" => "2", "d" => "4" } }
-    let!(:missing_all_keys) { HstoreRecord.create! :properties => { "c" => "3", "d" => "4" } }
+    let!(:match_1) { HstoreRecord.create! properties: { "a" => "1", "c" => "3" } }
+    let!(:match_2) { HstoreRecord.create! properties: { "b" => "2", "d" => "4" } }
+    let!(:missing_all_keys) { HstoreRecord.create! properties: { "c" => "3", "d" => "4" } }
 
     def self.shared_examples
       it { should include(match_1) }

--- a/spec/hstore/serializer_spec.rb
+++ b/spec/hstore/serializer_spec.rb
@@ -58,7 +58,7 @@ describe Surus::Hstore::Serializer do
 
   round_trip_examples.each do |value, description|
     it "round trips when #{description}" do
-      r = HstoreRecord.create! :properties => value
+      r = HstoreRecord.create! properties: value
       r.reload
       expect(r.properties).to eq(value)
     end

--- a/spec/synchronous_commit/connection_spec.rb
+++ b/spec/synchronous_commit/connection_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Surus::SynchronousCommit::Connection, :disable_transactions => true do
+describe Surus::SynchronousCommit::Connection, disable_transactions: true do
   let(:conn) { ActiveRecord::Base.connection }
   before { conn.execute "SET synchronous_commit TO ON;" }
   after { conn.execute "SET synchronous_commit TO ON;" }


### PR DESCRIPTION
Hi JackC,

This PR upgrades the whole project into the Ruby 1.9 Hash Syntax.

As we don't support ruby 1.8 (At least from what i've seen in the travis CI build). 

We should favor using the latest improvements for the ruby syntax. 

Pretty much, scavenges the changes that were done in https://github.com/jackc/surus/pull/20 for the hash changes.

Thanks for looking into it.

Meta-Issue : https://github.com/jackc/surus/pull/20