### PR TITLE
Test DateTime timezone different than UTC

### DIFF
--- a/spec/hstore/serializer_spec.rb
+++ b/spec/hstore/serializer_spec.rb
@@ -63,4 +63,14 @@ describe Surus::Hstore::Serializer do
       expect(r.properties).to eq(value)
     end
   end
+
+  context 'Stringify' do
+    it 'should store the values as UTC for Date' do
+      date = ::Time.find_zone!('Melbourne').now.to_datetime
+      serializer = Surus::Hstore::Serializer.new
+      result = serializer.stringify date
+      expect(result).to eq([date.to_s(:db), "Date"])
+      expect(result).to_not eq([date.to_s, "Date"])
+    end
+  end
 end


### PR DESCRIPTION
This PR adds a unit test to make sure that Date object with different timezone are serialized with the :db option.

Related PR issue  :  https://github.com/jackc/surus/pull/26