### PR TITLE
Ruby 2.3 on CI + Updates ruby 2.1 & 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ gemfile:
   - gemfiles/4.1.gemfile
   - gemfiles/4.2.gemfile
 
+matrix:
+  allow_failures:
+    - rvm: rbx-2.9
+
 addons:
   postgresql: "9.2"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: ruby
 rvm:
-  - 2.2.0
-  - 2.1.5
+  - 2.3.0
+  - 2.2.4
+  - 2.1.8
   - 2.0.0
-  - rbx-2.5.2
+  - rbx-2.9
 gemfile:
   - gemfiles/4.0.gemfile
   - gemfiles/4.1.gemfile


### PR DESCRIPTION
Run Travis CI on new Ruby 2.3 + Bump minor versions or ruby 2.1 & 2.2