### PR TITLE
Fix has_and_belongs_to_many scope primary key

### DIFF
--- a/lib/surus/json/has_and_belongs_to_many_scope_builder.rb
+++ b/lib/surus/json/has_and_belongs_to_many_scope_builder.rb
@@ -5,13 +5,17 @@ module Surus
         s = association
           .klass
           .joins("JOIN #{join_table} ON #{join_table}.#{association_foreign_key}=#{association_table}.#{association_primary_key}")
-          .where("#{outside_class.quoted_table_name}.#{association_primary_key}=#{join_table}.#{foreign_key}")
+          .where("#{outside_class.quoted_table_name}.#{primary_key}=#{join_table}.#{foreign_key}")
         s = s.instance_eval(&association.scope) if association.scope
         s
       end
 
       def join_table
         connection.quote_table_name association.join_table
+      end
+
+      def primary_key
+        connection.quote_table_name association.active_record_primary_key
       end
 
       def association_foreign_key


### PR DESCRIPTION
Found a bug where if the outside_class had a nonstandard primary key, the where clause would break. 