### PR TITLE
Include table name in queries to avoid ambiguous column errors.

### DIFF
--- a/lib/surus/json/belongs_to_scope_builder.rb
+++ b/lib/surus/json/belongs_to_scope_builder.rb
@@ -4,9 +4,17 @@ module Surus
       def scope
         s = association
           .klass
-          .where("#{quote_column_name association.active_record_primary_key}=#{quote_column_name association.foreign_key}")
+          .where("#{association_primary_key}=#{association_foreign_key}")
         s = s.instance_eval(&association.scope) if association.scope
         s
+      end
+
+      def association_primary_key
+        "#{association.quoted_table_name}.#{quote_column_name association.active_record_primary_key}"
+      end
+
+      def association_foreign_key
+        "#{outside_class.quoted_table_name}.#{quote_column_name association.foreign_key}"
       end
     end
   end

--- a/lib/surus/json/has_many_scope_builder.rb
+++ b/lib/surus/json/has_many_scope_builder.rb
@@ -14,7 +14,7 @@ module Surus
       end
 
       def association_foreign_key
-        "#{connection.quote_column_name association.foreign_key}"
+        "#{association.quoted_table_name}.#{connection.quote_column_name association.foreign_key}"
       end
     end
   end


### PR DESCRIPTION
Problem: surus-generated queries can contain ambiguous column errors if more than one table has the same column name.

For example, consider this schema:

```ruby
User
has_many :books
has_many :favorites

Book
belongs_to :user # book author
has_many :favorites

Favorite
belongs_to :book
belongs_to :user
```

And the query:

```ruby
some_user.notebooks.all_json(
  include: {
    favorites: {
      columns: [:id, :user_id]
    },
    user: {
      columns: [:id, :name]
    }
  }
)
```

Surus will generate a query like:
```sql
select array_to_json(coalesce(array_agg(row_to_json(t)), '{}')) from (SELECT books.id, books.name, books.user_id, (select array_to_json(coalesce(array_agg(row_to_json(t)), '{}')) from (SELECT favorites.id, favorites.user_id FROM "favorites" WHERE ("books"."id"="book_id")) t) "favorites", (select row_to_json(t) from (SELECT users.id, users.name FROM "users" WHERE ("id"="user_id")) t) "user" FROM "favorites" WHERE "favorites"."user_id" = 12345) t;
```

of which the important part is

```sql
(SELECT users.id, users.name FROM "users" WHERE ("id"="user_id"))
```

The `user_id` column is not scoped by table and it generates an ambiguous column error because there are two potentially matching columns (the `user_id` on Book and the `user_id` on Favorite). 

This PR simply adds the table name where it is currently omitted to prevent any ambiguity.