### PR TITLE
Remove use of `quoted_table_name` for Rails 5.2 compatibility

### DIFF
--- a/lib/surus/json/belongs_to_scope_builder.rb
+++ b/lib/surus/json/belongs_to_scope_builder.rb
@@ -10,11 +10,11 @@ module Surus
       end
 
       def association_primary_key
-        "#{association.quoted_table_name}.#{quote_column_name association.active_record_primary_key}"
+        "#{quote_table_name association.table_name}.#{quote_column_name association.active_record_primary_key}"
       end
 
       def association_foreign_key
-        "#{outside_class.quoted_table_name}.#{quote_column_name association.foreign_key}"
+        "#{quote_table_name outside_class.table_name}.#{quote_column_name association.foreign_key}"
       end
     end
   end

--- a/lib/surus/json/has_and_belongs_to_many_scope_builder.rb
+++ b/lib/surus/json/has_and_belongs_to_many_scope_builder.rb
@@ -5,33 +5,33 @@ module Surus
         s = association
           .klass
           .joins("JOIN #{join_table} ON #{join_table}.#{association_foreign_key}=#{association_table}.#{association_primary_key}")
-          .where("#{outside_class.quoted_table_name}.#{primary_key}=#{join_table}.#{foreign_key}")
+          .where("#{quote_table_name outside_class.table_name}.#{primary_key}=#{join_table}.#{foreign_key}")
         s = s.instance_eval(&association.scope) if association.scope
         s
       end
 
       def join_table
-        connection.quote_table_name association.join_table
+        quote_table_name association.join_table
       end
 
       def primary_key
-        connection.quote_table_name association.active_record_primary_key
+        quote_table_name association.active_record_primary_key
       end
 
       def association_foreign_key
-        connection.quote_column_name association.association_foreign_key
+        quote_column_name association.association_foreign_key
       end
 
       def foreign_key
-        connection.quote_column_name association.foreign_key
+        quote_column_name association.foreign_key
       end
 
       def association_table
-        connection.quote_table_name association.klass.table_name
+        quote_table_name association.klass.table_name
       end
 
       def association_primary_key
-        connection.quote_column_name association.association_primary_key
+        quote_column_name association.association_primary_key
       end
 
     end

--- a/lib/surus/json/has_many_scope_builder.rb
+++ b/lib/surus/json/has_many_scope_builder.rb
@@ -10,11 +10,11 @@ module Surus
       end
 
       def outside_primary_key
-        "#{outside_class.quoted_table_name}.#{connection.quote_column_name association.active_record_primary_key}"
+        "#{quote_table_name outside_class.table_name}.#{connection.quote_column_name association.active_record_primary_key}"
       end
 
       def association_foreign_key
-        "#{association.quoted_table_name}.#{connection.quote_column_name association.foreign_key}"
+        "#{quote_table_name association.table_name}.#{connection.quote_column_name association.foreign_key}"
       end
     end
   end

--- a/lib/surus/json/has_many_through_scope_builder.rb
+++ b/lib/surus/json/has_many_through_scope_builder.rb
@@ -30,7 +30,7 @@ module Surus
       end
 
       def outside_table
-        outside_class.quoted_table_name
+        quote_table_name outside_class.table_name
       end
 
       def outside_primary_key
@@ -42,7 +42,7 @@ module Surus
       end
 
       def through_table
-        through_reflection.quoted_table_name
+        quote_table_name through_reflection.table_name
       end
 
       def through_primary_key


### PR DESCRIPTION
Rails removed `quoted_table_name` from AR::Reflection
https://github.com/rails/rails/commit/b3f702febfdc6425b89a6a3b3040d0ecc963f41f