### PR TITLE
gemspec: Drop defunct property rubyforge_project

### DIFF
--- a/surus.gemspec
+++ b/surus.gemspec
@@ -16,8 +16,6 @@ Gem::Specification.new do |s|
                     50% or more. }
   s.license     = 'MIT'
 
-  s.rubyforge_project = ""
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* [rubygems/rubygems#2436 deprecated the `rubyforge_project` property][2].

[1]: https://twitter.com/evanphx/status/399552820380053505
[2]: rubygems/rubygems#2436